### PR TITLE
Fix incorrect class name extension for Monolog

### DIFF
--- a/Logger/Logger.php
+++ b/Logger/Logger.php
@@ -3,6 +3,6 @@
 namespace Paycomet\Payment\Logger;
 
 // @codingStandardsIgnoreFile
-class Logger extends \MonoLog\Logger
+class Logger extends \Monolog\Logger
 {
 }


### PR DESCRIPTION
This PR fixes an issue when placing an order:
- Magento version 2.4.2
- Steps to reproduce
-- Add a product to the cart, go to checkout, fill the form and use paycomet to complete payment data
-- Place the order
--- Expected result: order is placed
--- Actual result: an exception is thrown:

`Magento \ Framework \ Exception \ LocalizedException
Tipo de bloque inválido: Paycomet\Payment\Block\Process\Process`

![image](https://user-images.githubusercontent.com/506393/140763042-efaa57bc-827f-42e8-b19a-0d3fdd11eb03.png)

The problem is a typo in the Paycomet\Payment\Logger\Logger class. It is extending \MonoLog\Logger, and it should be \Monolog\Logger.

It would be nice having the Issues section opened.