### PR TITLE
Update PaymentMethod.php para un mejor funcionamiento con la orden de pedido en magento.

### DIFF
--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -348,7 +348,7 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod impleme
 
         // New Card or Token Card with 3D SecurePayment
         // Initialize order to PENDING_PAYMENT
-        $stateObject->setState(Order::STATE_PENDING_PAYMENT);
+        $stateObject->setState(Order::STATE_NEW);
         $stateObject->setStatus(Order::STATE_PENDING_PAYMENT);
         $stateObject->setIsNotified(false);
 


### PR DESCRIPTION
Después de estar trabajando con la orden de pedido, hemos visto que para Magento, el "state" del pedido, son internos de Magento, haciendo que este estado al crearse con Order::STATE_PENDING_PAYMENT nunca salga en el resto de plug-in, por eso hemos optado por modificarlo para que use el estado Order::STATE_NEW, para que se asimile más al funcionamiento interno de Magento. 

